### PR TITLE
Security fixes: resolve 6 issues found by SecureHandoff

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,4 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "vite": "^7.0.5"
+    "vite": "^7.3.5"
   }
 }


### PR DESCRIPTION
This pull request was generated by **SecureHandoff** after scanning this repository with its security suite (OSV.dev dependency analysis, secrets detection, static analysis, configuration checks, and - when connected - Snyk and Aikido Security).

## Changes in this PR

- Bump `vite` from `^7.0.5` to `^7.3.5` (minimum patched version per SCA advisories)
- `package-lock.json` could not be regenerated automatically - run `npm install` locally
- Add `node_modules/` to `.gitignore`

## Findings resolved

- **HIGH** vite@7.0.5: vite: `server.fs.deny` bypass on Windows alternate paths (CWE-200) - `package-lock.json`
- **MEDIUM** vite@7.0.5: Vite Vulnerable to Path Traversal in Optimized Deps `.map` Handling (CWE-200) - `package-lock.json`
- **MEDIUM** vite@7.0.5: vite allows server.fs.deny bypass via backslash on Windows (CWE-22) - `package-lock.json`
- **LOW** vite@7.0.5: Vite middleware may serve files starting with the same name with the public directory (CWE-200) - `package-lock.json`
- **LOW** vite@7.0.5: Vite's `server.fs` settings were not applied to HTML files (CWE-200) - `package-lock.json`
- **LOW** node_modules is not listed in .gitignore - `.gitignore`

## Requires manual attention

These findings need a human decision and are **not** fixed by this PR:

- [ ] **HIGH** picomatch@4.0.3: Picomatch has a ReDoS vulnerability via extglob quantifiers (CWE-1333) - `package-lock.json`
  Picomatch has a ReDoS vulnerability via extglob quantifiers (CVE-2026-33671)
- [ ] **HIGH** rollup@4.45.1: Rollup 4 has Arbitrary File Write via Path Traversal (CWE-22) - `package-lock.json`
  Rollup 4 has Arbitrary File Write via Path Traversal (CVE-2026-27606)
- [ ] **MEDIUM** picomatch@4.0.3: Picomatch: Method Injection in POSIX Character Classes causes incorrect Glob Matching (CWE-1321) - `package-lock.json`
  Picomatch: Method Injection in POSIX Character Classes causes incorrect Glob Matching (CVE-2026-33672)
- [ ] **MEDIUM** postcss@8.5.6: PostCSS has XSS via Unescaped </style> in its CSS Stringify Output (CWE-79) - `package-lock.json`
  PostCSS has XSS via Unescaped </style> in its CSS Stringify Output (CVE-2026-41305)